### PR TITLE
Example's of spark Memory configurations

### DIFF
--- a/spark-Conf-Param.txt
+++ b/spark-Conf-Param.txt
@@ -1,0 +1,1 @@
+https://spoddutur.github.io/spark-notes/distribution_of_executors_cores_and_memory_for_spark_application.html


### PR DESCRIPTION
URL of Spark Memory configuration
[spark-Conf-Param.txt](https://github.com/ManikandanJeyabal/Notes/files/2518990/spark-Conf-Param.txt)
